### PR TITLE
feat(Front-end) Add Combination of Tree and Bamboo Class

### DIFF
--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -235,6 +235,7 @@ function Annotation() {
           <li className="ptype" data-ptype="7"><button className="ptypeBtn" data-ptype="7" onClick={handleClassChange}>樹林</button></li>
           <li className="ptype" data-ptype="8"><button className="ptypeBtn" data-ptype="8" onClick={handleClassChange}>竹林</button></li>
           <li className="ptype" data-ptype="9"><button className="ptypeBtn" data-ptype="9" onClick={handleClassChange}>旱地</button></li>
+          <li className="ptype" data-ptype="10"><button className="ptypeBtn" data-ptype="10" onClick={handleClassChange}>樹竹</button></li>
         </ul>
         <button onClick={handleToggleDrawing}>{isDrawing ? '停止繪製多邊形' : '繪製多邊形'}</button>
         <button onClick={handleToggleSamModel}>{isSamModel ? '停止 SAM 模式' : '啟動 SAM 模式'}</button>


### PR DESCRIPTION
#2 
This pull request includes a small change to the `src/Annotation.js` file. The change adds a new button for the "樹竹" (Tree Bamboo) category to the list of classification buttons.

* [`src/Annotation.js`](diffhunk://#diff-e2e342baf7d0e5f6d208a44a872a0c750acd40c76f216b84495fe565797c1ae4R238): Added a new button with `data-ptype="10"` and label "樹竹" to the list of classification buttons in the `Annotation` component.